### PR TITLE
Set `CODEQL_DIST` before calling CodeQL CLI

### DIFF
--- a/gh-codeql
+++ b/gh-codeql
@@ -168,4 +168,5 @@ if [ -z "$version" ]; then
     version="$(gh config get extensions.codeql.version)"
 fi
 download "$version"
+export CODEQL_DIST="$rootdir/dist/$channel/$version"
 exec "$rootdir/dist/$channel/$version/codeql" "$@"


### PR DESCRIPTION
Closes https://github.com/github/gh-codeql/issues/3

I think we want to set `CODEQL_DIST` before calling the CLI to ensure that we actually run things with the CLI that we intended and don't end up calling out a different dist if the user had this variable set already.