### PR TITLE
CI Checks: Fix and improve stability

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -24,10 +24,26 @@ jobs:
         run: |
           gh extensions install .
 
+      - name: Check automatically installs latest
+        shell: bash
+        run: |
+          LATEST=`gh release list --repo github/codeql-cli-binaries -L 1 | cut -f 3`
+
+          # Note we need to run a command before trying to parse the output below, or the
+          # messages from the download will end up in the JSON that jq tries to parse
+          gh codeql version 
+          
+          INSTALLED=`gh codeql version --format json | jq -r '.version'`
+          if [[ "v$INSTALLED" != $LATEST ]]; then
+            echo "::error::Expected latest version of $LATEST to be installed, but found v$INSTALLED"
+            exit 1
+          fi
+
       - name: Check basic functionality
         working-directory: test-resources
         shell: bash
         run: |
+          gh codeql set-version 2.6.1
           gh codeql database create -l cpp -s test-repo -c "gcc -o main main.c" test-db
           gh codeql pack install test-pack
           gh codeql database analyze --format=sarif-latest --output=out.sarif test-db test-pack/allExpressions.ql

--- a/test-resources/test-pack/qlpack.yml
+++ b/test-resources/test-pack/qlpack.yml
@@ -1,4 +1,4 @@
 name: test-cpp-querypack
 version: 0.0.1
 dependencies:
-  codeql/cpp-all: "*"
+  codeql/cpp-all: "0.0.2"


### PR DESCRIPTION
This PR makes two changes to the CI checks on this repo:

1. The end-to-end test that uses a query pack and a test repository is currently flaky due to a delay between when a new CLI version is released and when a new version of the library pack it uses is released. This PR changes it to always use a fixed version of the CLI and library pack which are known to work together.
2. The above change loses us test coverage of the latest version being installed by default. I've added a new test to verify this.