### PR TITLE
Fix legal name in copyright notice

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 GitHub
+Copyright (c) 2021 GitHub, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Per @tom-corbett's advice, this updates the legal name in the copyright notice to GitHub, Inc.