### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @github/codeql-core
+* @github/codeql-cli-reviewers 


### PR DESCRIPTION
In preparation for open-sourcing this repo, this PR adds a `CODEOWNERS` file to the repository so that a team gets asked to review any potential PRs. For now, I've used the whole @github/codeql-core team here as we do not have an appropriate reviewer sub-team for this repository and given this will probably be fairly low-traffic it doesn't seem worth creating one.