### PR TITLE
Sort versions by their semantic version number

### DIFF
--- a/gh-codeql
+++ b/gh-codeql
@@ -95,7 +95,7 @@ fi
 function download() {
     local version="$1"
     if [ -z "$version" ] || [ "$version" = "latest" ]; then
-        version=$(gh api "repos/$repo/releases/latest" --jq '.tag_name')
+        version=$(gh api "repos/$repo/releases" --paginate --jq '.[].tag_name' | sort -V | tail -1)
     fi
     if [ -x "$rootdir/dist/$channel/$version/codeql" ] ; then
         # Already downloaded.


### PR DESCRIPTION
Closes https://github.com/github/gh-codeql/issues/13

As @aibaars points out, the current method to select the `latest` version relies of the order of the release date. This is unsound if we release a patch to an old version. Instead, we should get all the releases and sort them by their semantic version number.