### PR TITLE
Add functionality to enable use with the VS Code CodeQL extension

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -141,6 +141,10 @@ jobs:
         shell: bash
         run: |
           gh codeql set-version latest
+          # We run the command with a version override twice such that first run will download the CodeQL CLI
+          # and the cURL output doesn't confuse the `jq` parser in the second run.
+          # This implicit download is to test that we properly support the implicit download of a requested version if it is not present.
+          GH_CODEQL_VERSION=v2.7.6 gh codeql version
           VERSION=`GH_CODEQL_VERSION=v2.7.6 gh codeql version --format json | jq -r '.version'`
 
           if [[ $VERSION != "2.7.6" ]]; then

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -125,6 +125,30 @@ jobs:
             exit 1
           fi
 
+      - name: Check local version pinning modification
+        shell: bash
+        run: |
+          gh codeql set-version latest
+          # Get the latest installed version
+          LATEST=`gh codeql version --format json | jq -r '.version'`
+          # Set a local version
+          gh codeql set-local-version 2.5.9
+          VERSION=`gh codeql version --format json | jq -r '.version'`
+          if [[ $VERSION != "2.5.9" ]]; then
+            echo "::error::Expected version 2.5.9 but got $VERSION"
+            exit 1
+          fi
+
+          # Modify the pinned version without using the CLI
+          echo v2.7.6 > .codeql-version
+          # We run the command twice to prevent cURL output from causing a `jq` parser error.
+          gh codeql version
+          VERSION=`gh codeql version --format json | jq -r '.version'`
+          if [[ $VERSION != "2.7.6" ]]; then
+            echo "::error::Expected version 2.7.6 but got $VERSION"
+            exit 1
+          fi
+
       - name: Check getting nightly version
         shell: bash
         run: |

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -139,6 +139,7 @@ jobs:
       - name: Check use of stub
         shell: bash
         run: |
+          gh codeql set-version latest
           VERSION=`gh codeql version --format json | jq -r '.version'`
 
           mkdir temp

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -136,6 +136,18 @@ jobs:
             exit 1
           fi
 
+      - name: Check version override
+        shell: bash
+        run: |
+          gh codeql set-version latest
+          gh codeql download v2.7.6
+          VERSION=`GH_CODEQL_VERSION=v2.7.6 gh codeql version --format json | jq -r '.version'`
+
+          if [[ $VERSION != "2.7.6" ]]; then
+            echo "::error::Expected version 2.7.6 but got $VERSION"
+            exit 1
+          fi
+
       - name: Check use of stub
         shell: bash
         run: |

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -109,6 +109,7 @@ jobs:
           fi
           popd
           rmdir temp
+          gh codeql unset-local-version
 
       - name: Check local version unpinning
         shell: bash
@@ -148,6 +149,7 @@ jobs:
             echo "::error::Expected version 2.7.6 but got $VERSION"
             exit 1
           fi
+          gh codeql unset-local-version
 
       - name: Check getting nightly version
         shell: bash

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -87,6 +87,8 @@ jobs:
       - name: Check local version pinning
         shell: bash
         run: |
+          # Enable local pinning
+          gh config set extensions.codeql.local-pinning true 2> /dev/null
           gh codeql set-version latest
           # Get the latest installed version
           LATEST=`gh codeql version --format json | jq -r '.version'`
@@ -110,10 +112,14 @@ jobs:
           popd
           rmdir temp
           gh codeql unset-local-version
+          # Disable local pinning
+          gh config set extensions.codeql.local-pinning false 2> /dev/null
 
       - name: Check local version unpinning
         shell: bash
         run: |
+          # Enable local pinning
+          gh config set extensions.codeql.local-pinning true 2> /dev/null
           gh codeql set-version latest
           # Get the latest installed version
           LATEST=`gh codeql version --format json | jq -r '.version'`
@@ -125,10 +131,14 @@ jobs:
             echo "::error::Expected $LATEST version but got 2.5.9"
             exit 1
           fi
+          # Disable local pinning
+          gh config set extensions.codeql.local-pinning false 2> /dev/null
 
       - name: Check local version pinning modification
         shell: bash
         run: |
+          # Enable local pinning
+          gh config set extensions.codeql.local-pinning true 2> /dev/null
           gh codeql set-version latest
           # Get the latest installed version
           LATEST=`gh codeql version --format json | jq -r '.version'`
@@ -150,6 +160,25 @@ jobs:
             exit 1
           fi
           gh codeql unset-local-version
+          # Disable local pinning
+          gh config set extensions.codeql.local-pinning false 2> /dev/null
+
+      - name: Check local version pinning is disbled by default
+        shell: bash
+        run: |
+          gh codeql set-version latest
+          # Get the latest installed version
+          LATEST=`gh codeql version --format json | jq -r '.version'`
+
+          # Modify the pinned version without using the CLI
+          echo v2.7.6 > .codeql-version
+          # We run the command twice to prevent cURL output from causing a `jq` parser error.
+          gh codeql version
+          VERSION=`gh codeql version --format json | jq -r '.version'`
+          if [[ $VERSION = "2.7.6" ]]; then
+            echo "::error::Expected version $LATEST but got $VERSION"
+            exit 1
+          fi
 
       - name: Check getting nightly version
         shell: bash

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -87,8 +87,8 @@ jobs:
       - name: Check local version pinning
         shell: bash
         run: |
-          # Enable local pinning
-          gh config set extensions.codeql.local-pinning true 2> /dev/null
+          # Enable local version support
+          gh codeql local-version on
           gh codeql set-version latest
           # Get the latest installed version
           LATEST=`gh codeql version --format json | jq -r '.version'`
@@ -112,14 +112,14 @@ jobs:
           popd
           rmdir temp
           gh codeql unset-local-version
-          # Disable local pinning
-          gh config set extensions.codeql.local-pinning false 2> /dev/null
+          # Disable local version support
+          gh codeql local-version off
 
       - name: Check local version unpinning
         shell: bash
         run: |
-          # Enable local pinning
-          gh config set extensions.codeql.local-pinning true 2> /dev/null
+          # Enable local version support
+          gh codeql local-version on
           gh codeql set-version latest
           # Get the latest installed version
           LATEST=`gh codeql version --format json | jq -r '.version'`
@@ -131,14 +131,14 @@ jobs:
             echo "::error::Expected $LATEST version but got 2.5.9"
             exit 1
           fi
-          # Disable local pinning
-          gh config set extensions.codeql.local-pinning false 2> /dev/null
+          # Disable local version support
+          gh codeql local-version off
 
       - name: Check local version pinning modification
         shell: bash
         run: |
-          # Enable local pinning
-          gh config set extensions.codeql.local-pinning true 2> /dev/null
+          # Enable local version support
+          gh codeql local-version on
           gh codeql set-version latest
           # Get the latest installed version
           LATEST=`gh codeql version --format json | jq -r '.version'`
@@ -160,8 +160,8 @@ jobs:
             exit 1
           fi
           gh codeql unset-local-version
-          # Disable local pinning
-          gh config set extensions.codeql.local-pinning false 2> /dev/null
+          # Disable local version support
+          gh codeql local-version off
 
       - name: Check local version pinning is disbled by default
         shell: bash
@@ -179,6 +179,7 @@ jobs:
             echo "::error::Expected version $LATEST but got $VERSION"
             exit 1
           fi
+          rm .codeql-version
 
       - name: Check getting nightly version
         shell: bash

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -135,6 +135,7 @@ jobs:
             echo "::error::Expected version 2.6.0+202108311306 but got $VERSION"
             exit 1
           fi
+          gh codeql set-channel release
 
       - name: Check version override
         shell: bash

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -163,7 +163,7 @@ jobs:
           # Disable local version support
           gh codeql local-version off
 
-      - name: Check local version pinning is disbled by default
+      - name: Check local version pinning is disabled by default
         shell: bash
         run: |
           gh codeql set-version latest

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -32,7 +32,7 @@ jobs:
           # Note we need to run a command before trying to parse the output below, or the
           # messages from the download will end up in the JSON that jq tries to parse
           gh codeql version 
-          
+
           INSTALLED=`gh codeql version --format json | jq -r '.version'`
           if [[ "v$INSTALLED" != $LATEST ]]; then
             echo "::error::Expected latest version of $LATEST to be installed, but found v$INSTALLED"
@@ -81,6 +81,47 @@ jobs:
           VERSION=`gh codeql version --format json | jq -r '.version'`
           if [[ $VERSION == "2.5.9" ]]; then
             echo "::error::Expected latest version but got 2.5.9"
+            exit 1
+          fi
+
+      - name: Check local version pinning
+        shell: bash
+        run: |
+          gh codeql set-version latest
+          # Get the latest installed version
+          LATEST=`gh codeql version --format json | jq -r '.version'`
+          # Set a local version
+          gh codeql set-local-version 2.5.9
+          VERSION=`gh codeql version --format json | jq -r '.version'`
+          if [[ $VERSION != "2.5.9" ]]; then
+            echo "::error::Expected version 2.5.9 but got $VERSION"
+            exit 1
+          fi
+
+          # Create a temp directory so we can  change the working directory
+          mkdir temp
+          pushd temp
+          OTHER_VERSION=`gh codeql version --format json | jq -r '.version'`
+
+           if [[ $OTHER_VERSION != $LATEST ]]; then
+            echo "::error::Expected version $LATEST but got $OTHER_VERSION"
+            exit 1
+          fi
+          popd
+          rmdir temp
+
+      - name: Check local version unpinning
+        shell: bash
+        run: |
+          gh codeql set-version latest
+          # Get the latest installed version
+          LATEST=`gh codeql version --format json | jq -r '.version'`
+          # Set a local version
+          gh codeql set-local-version 2.5.9
+          # Unset the local version
+          gh codeql unset-local-version
+          if [[ $VERSION == "2.5.9" ]]; then
+            echo "::error::Expected $LATEST version but got 2.5.9"
             exit 1
           fi
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -103,7 +103,7 @@ jobs:
           pushd temp
           OTHER_VERSION=`gh codeql version --format json | jq -r '.version'`
 
-           if [[ $OTHER_VERSION != $LATEST ]]; then
+          if [[ $OTHER_VERSION != $LATEST ]]; then
             echo "::error::Expected version $LATEST but got $OTHER_VERSION"
             exit 1
           fi

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -141,7 +141,6 @@ jobs:
         shell: bash
         run: |
           gh codeql set-version latest
-          gh codeql download v2.7.6
           VERSION=`GH_CODEQL_VERSION=v2.7.6 gh codeql version --format json | jq -r '.version'`
 
           if [[ $VERSION != "2.7.6" ]]; then

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -135,3 +135,18 @@ jobs:
             echo "::error::Expected version 2.6.0+202108311306 but got $VERSION"
             exit 1
           fi
+
+      - name: Check use of stub
+        shell: bash
+        run: |
+          VERSION=`gh codeql version --format json | jq -r '.version'`
+
+          mkdir temp
+          gh codeql install-stub temp
+          OTHER_VERSION=`temp/codeql version --format json | jq -r '.version'`
+          if [[ $OTHER_VERSION != $VERSION ]]; then
+            echo "::error::Expected version $VERSION but got $OTHER_VERSION"
+            exit 1
+          fi
+
+          rm -r temp

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ You can list the installed versions from the current channel with `gh codeql lis
 
 ### Versions
 
-The `gh codeql` command always works relative to a pinned version on the current channel. You can manually specify the pinned version using `gh codeql set-version`.
+The `gh codeql` command always works relative to a pinned version on the current channel. You can manually specify the pinned version using `gh codeql set-version`. To pin a version to a working directory you can use the command `gh codeql set-local-version` and `gh codeql` will always use that version when running in that working directory. To remove a pin from a working directory run `gh codeql unset-local-version` in that working directory.
 
 You can download additional versions without pinning them (perhaps to prepare for local comparisons) using `gh codeql download`.
 

--- a/README.md
+++ b/README.md
@@ -15,12 +15,15 @@ GitHub command-line wrapper for the CodeQL CLI.
 Usage:
     gh codeql set-channel [release|nightly]     # default: release
     gh codeql set-version [version]             # default: latest
+    gh codeql set-local-version [version]       # set the version for the current working directory, default: latest
+    gh codeql unset-local-version               # switch back to the global version
     gh codeql list-versions                     # list all available versions for current channel
     gh codeql list-installed                    # list installed versions for current channel
     gh codeql cleanup <version>                 # delete a specific downloaded version
     gh codeql cleanup-all                       # delete all installed versions for all channels
     gh codeql download [version]                # download a specific version (default: latest)
     gh codeql debug [on|off]                    # enable/disable debug output for gh extension
+    gh codeql install-stub [dir]                # default: /usr/local/bin/
     gh codeql <anything else>                   # pass arguments to CodeQL CLI
 
 Current channel: release.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ You can download additional versions without pinning them (perhaps to prepare fo
 
 To upgrade, run `gh codeql set-version latest`, which will pin you to the current latest version.
 
+### CodeQL stub
+
+If you want to use the GitHub CLI managed CodeQL version directly in a terminal or use it with the Visual Studio Code CodeQL extension then you can install a stub using the command `gh codeql install-stub` that will install a Bash script called `codeql` that invokes the GitHub CLI. The default install directory is `/usr/local/bin/`, but you can change this by passing an existing directory.
+
 ## Development
 
 This extension is newly released and under active development. Contributions are very welcome, for more information about how you can contribute, please check our [CONTRIBUTING.md](CONTRIBUTING.md) file. For a list of outstanding issues, please take a look at [our backlog](https://github.com/github/gh-codeql/issues). If you encounter a problem that does not already have an open issue associated with it, please open one there.

--- a/gh-codeql
+++ b/gh-codeql
@@ -191,14 +191,19 @@ function install_stub() {
         error "The directory $bindir doesn't exist, please provide a different directory like 'gh codeql install-stub [dir]' to install a stub."
     fi
 
-    cat << "_codeql_stub" > "$bindir/codeql"
+    if [ -w "$bindir" ]; then
+
+        cat << "_codeql_stub" > "$bindir/codeql"
 #!/usr/bin/env bash
 
 set -e
 exec -a codeql gh codeql "$@"
 _codeql_stub
 
-    chmod +x "$bindir/codeql"
+        chmod +x "$bindir/codeql"
+    else
+        error "Missing write permission on $bindir. Please provide a directory with write permissions to install a stub."
+    fi
 }
 
 # Handle the download command.

--- a/gh-codeql
+++ b/gh-codeql
@@ -188,7 +188,7 @@ function install_stub() {
     fi
 
     if [ ! -e "$bindir" ]; then
-        error "The directory $bindir doesn't exist, cannot install stub!"
+        error "The directory $bindir doesn't exist, please provide a different directory like 'gh codeql install-stub [dir]' to install a stub."
     fi
 
     cat << "_codeql_stub" > "$bindir/codeql"

--- a/gh-codeql
+++ b/gh-codeql
@@ -14,8 +14,9 @@ error() {
 rootdir="$(dirname "$0")"
 channel="$(gh config get extensions.codeql.channel 2> /dev/null)" || : # Suppress an error and return empty if the field doesn't exist
 version="$(gh config get extensions.codeql.version 2> /dev/null)" || : # Suppress an error and return empty if the field doesn't exist
+local_pinning="$(gh config get extensions.codeql.local-pinning 2> /dev/null)" || : # Suppress an error and return empty if the field doesn't exist
 
-if [ -e .codeql-version ]; then
+if [ "$local_pinning" = "true" -a -e .codeql-version ]; then
     version=$(<.codeql-version)
 fi
 
@@ -171,6 +172,9 @@ function validate_version() {
 
 function set_version() {
     local version=$(validate_version "$1")
+    if [ -z "$version" ]; then
+        exit 1
+    fi
     download "$version"
     gh config set extensions.codeql.version "$version" 2> /dev/null # Ignore a warning about unrecognized custom keys
 }
@@ -221,9 +225,25 @@ fi
 
 # Handle the set-local-version command
 if [ "$1" = "set-local-version" ]; then
-    set_local_version "$2"
-    version="$(<.codeql-version)" || : # Supress an error and return empty if the file doesn't exist
-    exec "$rootdir/dist/$channel/$version/codeql" version
+    if [ "$local_pinning" = "true" ]; then
+        set_local_version "$2"
+        version="$(<.codeql-version)" || : # Supress an error and return empty if the file doesn't exist
+        exec "$rootdir/dist/$channel/$version/codeql" version
+    else
+        cat << _message
+The 'set-local-version' command is disabled by default to remove the opportunity from untrusted git repositories to
+abuse older CodeQL CLIs.
+_message
+        read -p "Type 'yes' to enable per directory pinning or anything else to cancel:" choice
+        if [ "$choice" = "yes" ]; then
+            gh config set extensions.codeql.local-pinning true 2> /dev/null
+            echo "Enabled per directory pinning, re-run the command to set the local version."
+            exit
+        else
+            echo "Per directory pinning remains disabled. Re-run the command if you want to enabled it."
+            exit
+        fi
+    fi
 fi
 
 # Handle the unset-local-version command

--- a/gh-codeql
+++ b/gh-codeql
@@ -37,7 +37,7 @@ Usage:
     gh codeql cleanup-all                       # delete all installed versions for all channels
     gh codeql download [version]                # download a specific version (default: latest)
     gh codeql debug [on|off]                    # enable/disable debug output for gh extension
-    gh codeql install-stub [dir]                # default: /usr/local/bin/
+    gh codeql install-stub [dir]                # install an executable script named 'codeql' that invokes 'gh codeql' with the passed arguments (default: /usr/local/bin/)
     gh codeql <anything else>                   # pass arguments to CodeQL CLI
 
 Current channel: ${channel:-not specified}.

--- a/gh-codeql
+++ b/gh-codeql
@@ -19,6 +19,9 @@ if [ -e .codeql-version ]; then
     version=$(<.codeql-version)
 fi
 
+# The environment variable GH_CODEQL_VERSION overrides all specified versions.
+version=${GH_CODEQL_VERSION:-$version}
+
 if [ -z "$1" ]; then
     cat <<EOF
 GitHub command-line wrapper for the CodeQL CLI.

--- a/gh-codeql
+++ b/gh-codeql
@@ -217,7 +217,7 @@ fi
 # Handle the set-local-version command
 if [ "$1" = "set-local-version" ]; then
     set_local_version "$2"
-    version="$(<.codeql-version)" || : # Supress an error and return emtpy if the file doesn't exist
+    version="$(<.codeql-version)" || : # Supress an error and return empty if the file doesn't exist
     exec "$rootdir/dist/$channel/$version/codeql" version
 fi
 

--- a/gh-codeql
+++ b/gh-codeql
@@ -15,6 +15,10 @@ rootdir="$(dirname "$0")"
 channel="$(gh config get extensions.codeql.channel 2> /dev/null)" || : # Suppress an error and return empty if the field doesn't exist
 version="$(gh config get extensions.codeql.version 2> /dev/null)" || : # Suppress an error and return empty if the field doesn't exist
 
+if [ -e .codeql-version ]; then
+    version=$(<.codeql-version)
+fi
+
 if [ -z "$1" ]; then
     cat <<EOF
 GitHub command-line wrapper for the CodeQL CLI.
@@ -22,6 +26,8 @@ GitHub command-line wrapper for the CodeQL CLI.
 Usage:
     gh codeql set-channel [release|nightly]     # default: release
     gh codeql set-version [version]             # default: latest
+    gh codeql set-local-version [version]       # set the version for the current working directory, default: latest
+    gh codeql unset-local-version               # switch back to the global version
     gh codeql list-versions                     # list all available versions for current channel
     gh codeql list-installed                    # list installed versions for current channel
     gh codeql cleanup <version>                 # delete a specific downloaded version
@@ -131,7 +137,7 @@ function download() {
     rm -rf "$tempdir"
 }
 
-function set_version() {
+function validate_version() {
     local version="$1"
     if [ -z "$version" ]; then
         error "Version must be specified. Use 'latest' to automatically determine the latest version."
@@ -156,8 +162,19 @@ function set_version() {
             error "Unknown version: '$1'."
         fi
     fi
+    echo "$version"
+}
+
+function set_version() {
+    local version=$(validate_version "$1")
     download "$version"
     gh config set extensions.codeql.version "$version" 2> /dev/null # Ignore a warning about unrecognized custom keys
+}
+
+function set_local_version() {
+    local version=$(validate_version "$1")
+    download "$version"
+    echo "$version" > .codeql-version
 }
 
 # Handle the download command.
@@ -171,6 +188,19 @@ if [ "$1" = "set-version" ]; then
     set_version "$2"
     version="$(gh config get extensions.codeql.version 2> /dev/null)" || : # Suppress an error and return empty if the field doesn't exist
     exec "$rootdir/dist/$channel/$version/codeql" version
+fi
+
+# Handle the set-local-version command
+if [ "$1" = "set-local-version" ]; then
+    set_local_version "$2"
+    version="$(<.codeql-version)" || : # Supress an error and return emtpy if the file doesn't exist
+    exec "$rootdir/dist/$channel/$version/codeql" version
+fi
+
+# Handle the unset-local-version command
+if [ "$1" = "unset-local-version" ]; then
+    rm -f .codeql-version
+    exit 0
 fi
 
 # Handle the list-installed command.

--- a/gh-codeql
+++ b/gh-codeql
@@ -250,7 +250,7 @@ if [ "$1" = "cleanup-all" ]; then
     exit 0
 fi
 
-# Hanlde the install-stub command
+# Handle the install-stub command
 if [ "$1" = "install-stub" ]; then
     install_stub "$2"
     exit 0

--- a/gh-codeql
+++ b/gh-codeql
@@ -28,7 +28,7 @@ abuse older CodeQL CLIs. To disable local version support again run the command 
     elif [ "$2" = "off" ] ; then
         gh config set extensions.codeql.local-version false 2> /dev/null # Ignore a warning about unrecognized custom keys
     else
-        error "Invalid local-version command: '$2'."
+        error "Invalid local-version command: '$2'. Supported values are 'on' or 'off'."
     fi
     exit 0
 fi

--- a/gh-codeql
+++ b/gh-codeql
@@ -34,6 +34,7 @@ Usage:
     gh codeql cleanup-all                       # delete all installed versions for all channels
     gh codeql download [version]                # download a specific version (default: latest)
     gh codeql debug [on|off]                    # enable/disable debug output for gh extension
+    gh codeql install-stub [dir]                # default: /usr/local/bin/
     gh codeql <anything else>                   # pass arguments to CodeQL CLI
 
 Current channel: ${channel:-not specified}.
@@ -177,6 +178,26 @@ function set_local_version() {
     echo "$version" > .codeql-version
 }
 
+function install_stub() {
+    local bindir="$1"
+    if [ -z "$bindir" ]; then
+        bindir="/usr/local/bin"
+    fi
+
+    if [ ! -e "$bindir" ]; then
+        error "The directory $bindir doesn't exist, cannot install stub!"
+    fi
+
+    cat << "_codeql_stub" > "$bindir/codeql"
+#!/usr/bin/env bash
+
+set -e
+exec -a codeql gh codeql "$@"
+_codeql_stub
+
+    chmod +x "$bindir/codeql"
+}
+
 # Handle the download command.
 if [ "$1" = "download" ]; then
     download "$2"
@@ -223,6 +244,12 @@ fi
 # Handle the cleanup-all command
 if [ "$1" = "cleanup-all" ]; then
     rm -rf "$rootdir/dist"
+    exit 0
+fi
+
+# Hanlde the install-stub command
+if [ "$1" = "install-stub" ]; then
+    install_stub "$2"
     exit 0
 fi
 

--- a/gh-codeql
+++ b/gh-codeql
@@ -11,13 +11,36 @@ error() {
     exit 1
 }
 
+warning() {
+    echo "WARNING: $*" 1>&2
+}
+
 rootdir="$(dirname "$0")"
 channel="$(gh config get extensions.codeql.channel 2> /dev/null)" || : # Suppress an error and return empty if the field doesn't exist
 version="$(gh config get extensions.codeql.version 2> /dev/null)" || : # Suppress an error and return empty if the field doesn't exist
-local_pinning="$(gh config get extensions.codeql.local-pinning 2> /dev/null)" || : # Suppress an error and return empty if the field doesn't exist
 
-if [ "$local_pinning" = "true" -a -e .codeql-version ]; then
-    version=$(<.codeql-version)
+# Handle local-version command first to prevent local version warning when enabling local version support if a local version is specified..
+if [ "$1" = "local-version" ] ; then
+    if [ "$2" = "on" ] ; then
+        warning "Local version support is disabled by default to remove the opportunity from untrusted git repositories to
+abuse older CodeQL CLIs. To disable local version support again run the command 'gh codeql local-version off'."
+        gh config set extensions.codeql.local-version true 2> /dev/null # Ignore a warning about unrecognized custom keys
+    elif [ "$2" = "off" ] ; then
+        gh config set extensions.codeql.local-version false 2> /dev/null # Ignore a warning about unrecognized custom keys
+    else
+        error "Invalid local-version command: '$2'."
+    fi
+    exit 0
+fi
+
+local_version="$(gh config get extensions.codeql.local-version 2> /dev/null)" || : # Suppress an error and return empty if the field doesn't exist
+
+if [ -e .codeql-version ]; then
+    if [ "$local_version" = "true" ]; then
+        version=$(<.codeql-version)
+    else
+        warning "Ignoring local version because local version support is off. Call the command 'gh codeql local-version on' to enable local version support. "
+    fi
 fi
 
 # The environment variable GH_CODEQL_VERSION overrides all specified versions.
@@ -30,6 +53,7 @@ GitHub command-line wrapper for the CodeQL CLI.
 Usage:
     gh codeql set-channel [release|nightly]     # default: release
     gh codeql set-version [version]             # default: latest
+    gh codeql local-version [on|off]            # enable/disable local version support
     gh codeql set-local-version [version]       # set the version for the current working directory, default: latest
     gh codeql unset-local-version               # switch back to the global version
     gh codeql list-versions                     # list all available versions for current channel
@@ -225,30 +249,26 @@ fi
 
 # Handle the set-local-version command
 if [ "$1" = "set-local-version" ]; then
-    if [ "$local_pinning" = "true" ]; then
+    if [ "$local_version" = "true" ]; then
         set_local_version "$2"
         version="$(<.codeql-version)" || : # Supress an error and return empty if the file doesn't exist
         exec "$rootdir/dist/$channel/$version/codeql" version
     else
-        cat << _message
-The 'set-local-version' command is disabled by default to remove the opportunity from untrusted git repositories to
-abuse older CodeQL CLIs.
+        error "$(cat << _message
+Local version support is disabled by default to remove the opportunity from untrusted git repositories to
+abuse older CodeQL CLIs. Enable local version support with the command 'gh codeql local-version on'.
 _message
-        read -p "Type 'yes' to enable per directory pinning or anything else to cancel:" choice
-        if [ "$choice" = "yes" ]; then
-            gh config set extensions.codeql.local-pinning true 2> /dev/null
-            echo "Enabled per directory pinning, re-run the command to set the local version."
-            exit
-        else
-            echo "Per directory pinning remains disabled. Re-run the command if you want to enabled it."
-            exit
-        fi
+)"
     fi
 fi
 
 # Handle the unset-local-version command
 if [ "$1" = "unset-local-version" ]; then
-    rm -f .codeql-version
+    if [ -e .codeql-version ]; then
+        rm -f .codeql-version
+    else
+        warning "No local version specified."
+    fi
     exit 0
 fi
 


### PR DESCRIPTION
This PR adds functionality for:

- per directory version pinning
- version overriding through an environment variable
- use with the VS Code CodeQL extension through a stub

The local pinning management is possible with the commands `set-local-version` and `unset-local-version` that works with a file `.codeql-version` in the current working directory.
The presence of this file overrides the version specified with `set-version` allowing for a per directory version specification.

The `install-stub` command installs a small Bash script called `codeql` that invokes `gh codeql`. The stub is required to be able to use the GitHub CLI managed CodeQL version in the Visual Studio Code CodeQL extension.

Finally, the version override through an environment variable enables one to have multiple Visual Studio Code instances using different version of the CodeQL CLI managed by the GitHub CLI. 
This does require an extra step in how Visual Studio Code is called. Currently I have the following alias for `code`

```bash
function code() {
    # first non-option argument, if any
    setopt local_options extended_glob unset
    local -i i=$argv[(i)^-*]
    dir_to_search=$(pwd)
    if [[ -n $argv[i] ]]; then
        if [ -d $argv[i] ]; then
            dir_to_search=$argv[i]
        else
            dir_to_search=$(dirname $argv[i])
        fi
    fi

    #echo "Looking $dir_to_search/.codeql-version"
    if [ -f "$dir_to_search/.codeql-version" ]; then
        export GH_CODEQL_VERSION=$(cat "$dir_to_search/.codeql-version")
        echo "Found .codeql-version, will use version $GH_CODEQL_VERSION"
        command code $@
    else
        #echo "Didn't find .codeql-version"
        command code $@
    fi
}
```