### PR TITLE
Use recent versions of the cli for running the tests

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -20,22 +20,38 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install extension
-        shell: bash
         run: |
           gh extensions install .
+
+      - name: Get recent CLI versions
+        shell: bash
+        run: |
+          THREE_VERSIONS="$(gh release list --repo github/codeql-cli-binaries -L 3 | cut -f 3)"
+          LATEST="$(echo $THREE_VERSIONS | awk '{print $1}')"
+          SECOND_LATEST="$(echo $THREE_VERSIONS | awk '{print $2}')"
+          THIRD_LATEST="$(echo $THREE_VERSIONS | awk '{print $3}')"
+
+          # Remove the leading v
+          LATEST=${LATEST:1}
+          SECOND_LATEST=${SECOND_LATEST:1}
+          THIRD_LATEST=${THIRD_LATEST:1}
+
+          echo "Using versions $LATEST, $SECOND_LATEST, : $THIRD_LATEST"
+
+          echo "LATEST=$LATEST" >> $GITHUB_ENV
+          echo "SECOND_LATEST=$SECOND_LATEST" >> $GITHUB_ENV
+          echo "THIRD_LATEST=$THIRD_LATEST" >> $GITHUB_ENV
 
       - name: Check automatically installs latest
         shell: bash
         run: |
-          LATEST=`gh release list --repo github/codeql-cli-binaries -L 1 | cut -f 3`
-
           # Note we need to run a command before trying to parse the output below, or the
           # messages from the download will end up in the JSON that jq tries to parse
-          gh codeql version 
+          gh codeql version
 
           INSTALLED=`gh codeql version --format json | jq -r '.version'`
-          if [[ "v$INSTALLED" != $LATEST ]]; then
-            echo "::error::Expected latest version of $LATEST to be installed, but found v$INSTALLED"
+          if [[ "$INSTALLED" != $LATEST ]]; then
+            echo "::error::Expected latest version of $LATEST to be installed, but found $INSTALLED"
             exit 1
           fi
 
@@ -43,7 +59,7 @@ jobs:
         working-directory: test-resources
         shell: bash
         run: |
-          gh codeql set-version 2.6.1
+          gh codeql set-version "$LATEST"
           gh codeql database create -l cpp -s test-repo -c "gcc -o main main.c" test-db
           gh codeql pack install test-pack
           gh codeql database analyze --format=sarif-latest --output=out.sarif test-db test-pack/allExpressions.ql
@@ -57,17 +73,17 @@ jobs:
         shell: bash
         run: |
           # Set the version without a v prefix
-          gh codeql set-version 2.5.9
+          gh codeql set-version "$SECOND_LATEST"
           VERSION=`gh codeql version --format json | jq -r '.version'`
-          if [[ $VERSION != "2.5.9" ]]; then
-            echo "::error::Expected version 2.5.9 but got $VERSION"
+          if [[ $VERSION != "$SECOND_LATEST" ]]; then
+            echo "::error::Expected version $SECOND_LATEST but got $VERSION"
             exit 1
           fi
-          gh codeql list-installed | grep v2.5.9
+          gh codeql list-installed | grep v$SECOND_LATEST
 
           # Set the version with a v prefix
           COUNT_BEFORE=`gh codeql list-installed | wc -l`
-          gh codeql set-version v2.5.9
+          gh codeql set-version v$SECOND_LATEST
           COUNT_AFTER=`gh codeql list-installed | wc -l`
           if [[ $COUNT_BEFORE != $COUNT_BEFORE ]]; then
             echo "::error::Installing an already installed version changed the number of installed versions from $COUNT_BEFORE to $COUNT_AFTER!"
@@ -79,8 +95,8 @@ jobs:
         run: |
           gh codeql set-version latest
           VERSION=`gh codeql version --format json | jq -r '.version'`
-          if [[ $VERSION == "2.5.9" ]]; then
-            echo "::error::Expected latest version but got 2.5.9"
+          if [[ $VERSION == "$SECOND_LATEST" ]]; then
+            echo "::error::Expected latest version but got $SECOND_LATEST"
             exit 1
           fi
 
@@ -93,10 +109,10 @@ jobs:
           # Get the latest installed version
           LATEST=`gh codeql version --format json | jq -r '.version'`
           # Set a local version
-          gh codeql set-local-version 2.5.9
+          gh codeql set-local-version $SECOND_LATEST
           VERSION=`gh codeql version --format json | jq -r '.version'`
-          if [[ $VERSION != "2.5.9" ]]; then
-            echo "::error::Expected version 2.5.9 but got $VERSION"
+          if [[ $VERSION != "$SECOND_LATEST" ]]; then
+            echo "::error::Expected version $SECOND_LATEST but got $VERSION"
             exit 1
           fi
 
@@ -124,11 +140,11 @@ jobs:
           # Get the latest installed version
           LATEST=`gh codeql version --format json | jq -r '.version'`
           # Set a local version
-          gh codeql set-local-version 2.5.9
+          gh codeql set-local-version $SECOND_LATEST
           # Unset the local version
           gh codeql unset-local-version
-          if [[ $VERSION == "2.5.9" ]]; then
-            echo "::error::Expected $LATEST version but got 2.5.9"
+          if [[ $VERSION == "$SECOND_LATEST" ]]; then
+            echo "::error::Expected $LATEST version but got $SECOND_LATEST"
             exit 1
           fi
           # Disable local version support
@@ -143,20 +159,20 @@ jobs:
           # Get the latest installed version
           LATEST=`gh codeql version --format json | jq -r '.version'`
           # Set a local version
-          gh codeql set-local-version 2.5.9
+          gh codeql set-local-version $SECOND_LATEST
           VERSION=`gh codeql version --format json | jq -r '.version'`
-          if [[ $VERSION != "2.5.9" ]]; then
-            echo "::error::Expected version 2.5.9 but got $VERSION"
+          if [[ $VERSION != "$SECOND_LATEST" ]]; then
+            echo "::error::Expected version $SECOND_LATEST but got $VERSION"
             exit 1
           fi
 
           # Modify the pinned version without using the CLI
-          echo v2.7.6 > .codeql-version
+          echo v$THIRD_LATEST > .codeql-version
           # We run the command twice to prevent cURL output from causing a `jq` parser error.
           gh codeql version
           VERSION=`gh codeql version --format json | jq -r '.version'`
-          if [[ $VERSION != "2.7.6" ]]; then
-            echo "::error::Expected version 2.7.6 but got $VERSION"
+          if [[ $VERSION != "$THIRD_LATEST" ]]; then
+            echo "::error::Expected version $THIRD_LATEST but got $VERSION"
             exit 1
           fi
           gh codeql unset-local-version
@@ -168,15 +184,15 @@ jobs:
         run: |
           gh codeql set-version latest
           # Get the latest installed version
-          LATEST=`gh codeql version --format json | jq -r '.version'`
+          LATEST_INSTALLED=`gh codeql version --format json | jq -r '.version'`
 
           # Modify the pinned version without using the CLI
-          echo v2.7.6 > .codeql-version
+          echo v$SECOND_LATEST > .codeql-version
           # We run the command twice to prevent cURL output from causing a `jq` parser error.
           gh codeql version
           VERSION=`gh codeql version --format json | jq -r '.version'`
-          if [[ $VERSION = "2.7.6" ]]; then
-            echo "::error::Expected version $LATEST but got $VERSION"
+          if [[ $VERSION = "$SECOND_LATEST" ]]; then
+            echo "::error::Expected version $LATEST_INSTALLED but got $VERSION"
             exit 1
           fi
           rm .codeql-version
@@ -184,11 +200,21 @@ jobs:
       - name: Check getting nightly version
         shell: bash
         run: |
+          set -exu
+
+          # unfortunately for nightly builds the tag name does not match with the version name
+          # (as it does for releases). So, we need to download by tag name and then check the version name.
+          LATEST_NIGHTLY_TAG="$(gh api "repos/dsp-testing/codeql-cli-nightlies/releases" --jq ".[] | select(.draft == false) | .tag_name" | head -1)"
+
+          # slightly hacky way of getting the version. Hopefully, we don't change how we format the release body.
+          LATEST_NIGHTLY_VERSION="$(gh api "repos/dsp-testing/codeql-cli-nightlies/releases" --jq '.[] | select(.draft == false) | .body '| head -n 1 | awk '{print $4}')"
+          echo "Download nightly version $LATEST_NIGHTLY_VERSION and tag $LATEST_NIGHTLY_TAG"
+
           gh codeql set-channel nightly
-          gh codeql set-version codeql-bundle-20210831-manual
+          gh codeql set-version "$LATEST_NIGHTLY_TAG"
           VERSION=`gh codeql version --format json | jq -r '.version'`
-          if [[ $VERSION != "2.6.0+202108311306" ]]; then
-            echo "::error::Expected version 2.6.0+202108311306 but got $VERSION"
+          if [[ "v$VERSION" != "$LATEST_NIGHTLY_VERSION" ]]; then
+            echo "::error::Expected version $LATEST_NIGHTLY_VERSION but got v$VERSION"
             exit 1
           fi
           gh codeql set-channel release
@@ -196,15 +222,16 @@ jobs:
       - name: Check version override
         shell: bash
         run: |
+          gh codeql set-channel release
           gh codeql set-version latest
           # We run the command with a version override twice such that first run will download the CodeQL CLI
           # and the cURL output doesn't confuse the `jq` parser in the second run.
           # This implicit download is to test that we properly support the implicit download of a requested version if it is not present.
-          GH_CODEQL_VERSION=v2.7.6 gh codeql version
-          VERSION=`GH_CODEQL_VERSION=v2.7.6 gh codeql version --format json | jq -r '.version'`
+          GH_CODEQL_VERSION=v$SECOND_LATEST gh codeql version
+          VERSION=`GH_CODEQL_VERSION=v$SECOND_LATEST gh codeql version --format json | jq -r '.version'`
 
-          if [[ $VERSION != "2.7.6" ]]; then
-            echo "::error::Expected version 2.7.6 but got $VERSION"
+          if [[ $VERSION != "$SECOND_LATEST" ]]; then
+            echo "::error::Expected version $SECOND_LATEST but got $VERSION"
             exit 1
           fi
 

--- a/test-resources/test-pack/qlpack.yml
+++ b/test-resources/test-pack/qlpack.yml
@@ -1,4 +1,4 @@
 name: test-cpp-querypack
 version: 0.0.1
 dependencies:
-  codeql/cpp-all: "0.0.2"
+  codeql/cpp-all: "*"


### PR DESCRIPTION
This workflow was failing since it was using an old version of the cli that can't run the latest queries. Instead, always ensure we are running the latest CLI and the two previous instances.

cc: dilanbhalla Let's see if this fixes the workflow.